### PR TITLE
Update aws-timemap.tf

### DIFF
--- a/provision/aws-instance/aws-timemap.tf
+++ b/provision/aws-instance/aws-timemap.tf
@@ -5,7 +5,6 @@ provider "aws" {
 
 resource "aws_s3_bucket" "timemap-bucket" {
   bucket = var.bucket-name
-  region=
   cors_rule {
     allowed_headers = ["*"]
     allowed_methods = ["GET"]


### PR DESCRIPTION
vars.cors_allowed_origins should be var.cors_allowed_origins
aws_s3_bucket - region attribute has depreciated and no longer configureable, needs removing (see: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/guides/version-3-upgrade#resource-aws_s3_bucket)